### PR TITLE
Add on_alternative_marked_as_winner callback - 151363141

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -19,6 +19,7 @@ module Split
     attr_accessor :on_trial
     attr_accessor :on_trial_choose
     attr_accessor :on_trial_complete
+    attr_accessor :on_alternative_marked_as_winner
     attr_accessor :on_experiment_reset
     attr_accessor :on_experiment_delete
     attr_accessor :on_before_experiment_reset
@@ -199,6 +200,7 @@ module Split
       @ignore_filter = proc{ |request| is_robot? || is_ignored_ip_address? }
       @db_failover = false
       @db_failover_on_db_error = proc{|error|} # e.g. use Rails logger here
+      @on_alternative_marked_as_winner = proc{|experiment|}
       @on_experiment_reset = proc{|experiment|}
       @on_experiment_delete = proc{|experiment|}
       @on_before_experiment_reset = proc{|experiment|}

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -149,6 +149,7 @@ module Split
 
     def winner=(winner_name)
       redis.hset(:experiment_winner, name, winner_name.to_s)
+      Split.configuration.on_alternative_marked_as_winner.call(self)
     end
 
     def participant_count

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -9,6 +9,10 @@ describe Split::Configuration do
     expect(@config.ignore_ip_addresses).to eq([])
   end
 
+  it "should provide a default proc for on_alternative_marked_as_winner" do
+    expect(@config.on_alternative_marked_as_winner).to be_an_instance_of(Proc)
+  end
+
   it "should provide default values for db failover" do
     expect(@config.db_failover).to be_falsey
     expect(@config.db_failover_on_db_error).to be_a Proc

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -221,6 +221,20 @@ describe Split::Experiment do
     end
   end
 
+  describe 'winner=' do
+    it "sets the corresponding value in the experiment_winner hash to the winning alternative name" do
+      expect { experiment.winner = 'red' }
+        .to change { Split.redis.hget(:experiment_winner, experiment.name) }
+        .from(nil)
+        .to('red')
+    end
+
+    it "calls the on_alternative_marked_as_winner hook" do
+      expect(Split.configuration.on_alternative_marked_as_winner).to receive(:call)
+      experiment.winner = 'red'
+    end
+  end
+
   describe 'has_winner?' do
     context 'with winner' do
       before { experiment.winner = 'red' }


### PR DESCRIPTION
We need to be able to hook into when an alternative is marked as a winner.

This PR introduces a new callback, on_alternative_marked_as_winner, it is called when the winner is set.