### PR TITLE
Add callback on_experiment_save

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -20,6 +20,7 @@ module Split
     attr_accessor :on_trial_choose
     attr_accessor :on_trial_complete
     attr_accessor :on_alternative_marked_as_winner
+    attr_accessor :on_experiment_save
     attr_accessor :on_experiment_reset
     attr_accessor :on_experiment_delete
     attr_accessor :on_before_experiment_reset
@@ -201,6 +202,7 @@ module Split
       @db_failover = false
       @db_failover_on_db_error = proc{|error|} # e.g. use Rails logger here
       @on_alternative_marked_as_winner = proc{|experiment|}
+      @on_experiment_save = proc{|experiment|}
       @on_experiment_reset = proc{|experiment|}
       @on_experiment_delete = proc{|experiment|}
       @on_before_experiment_reset = proc{|experiment|}

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -89,6 +89,7 @@ module Split
 
       redis.hset(experiment_config_key, :resettable, resettable)
       redis.hset(experiment_config_key, :algorithm, algorithm.to_s)
+      Split.configuration.on_experiment_save.call(self)
       self
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -13,6 +13,10 @@ describe Split::Configuration do
     expect(@config.on_alternative_marked_as_winner).to be_an_instance_of(Proc)
   end
 
+  it "should provide a default proc for on_experiment_save" do
+    expect(@config.on_experiment_save).to be_an_instance_of(Proc)
+  end
+
   it "should provide default values for db failover" do
     expect(@config.db_failover).to be_falsey
     expect(@config.db_failover_on_db_error).to be_a Proc

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -40,6 +40,11 @@ describe Split::Experiment do
       expect(Split.redis.exists('basket_text')).to be true
     end
 
+    it "calls the on_experiment_save hook when saved" do
+      expect(Split.configuration.on_experiment_save).to receive(:call)
+      experiment.save
+    end
+
     it "should save the start time to redis" do
       experiment_start_time = Time.at(1372167761)
       expect(Time).to receive(:now).and_return(experiment_start_time)


### PR DESCRIPTION
We need to be able to stay up to date with when new experiments are added dynamically. The easiest way of doing this is hooking into when an experiment is saved. This PR adds an `on_experiment_save` callback that is called at the end of `Split::Experiment#save`.